### PR TITLE
Adding null UUID constant & CLI option

### DIFF
--- a/Sources/UuidTools/Extensions/Foundation/UUID + constants.swift
+++ b/Sources/UuidTools/Extensions/Foundation/UUID + constants.swift
@@ -12,4 +12,7 @@ import Foundation
 public extension UUID {
     /// Some example UUID. This is never guaranteed to be the same
     static let example = Self()
+    
+    /// The "nil" UUID (`00000000-0000-0000-0000-000000000000`), often used to represent "no value" or as a placeholder.
+    static let null = Self(uuid: uuid_t(0,0,0,0, 0,0, 0,0, 0,0, 0,0,0,0,0,0))
 }

--- a/Sources/kyuuid/commands/kyuuid.swift
+++ b/Sources/kyuuid/commands/kyuuid.swift
@@ -25,7 +25,7 @@ struct kyuuid: ParsableCommand {
         """,
 
         // Commands can define a version for automatic '--version' support.
-        version: "0.1.3-lambda.1",
+        version: "0.2.2",
 
         // Pass an array to `subcommands` to set up a nested tree of subcommands.
         // With language support for type-level introspection, this could be
@@ -39,9 +39,13 @@ struct kyuuid: ParsableCommand {
     @Option(help: "The number of UUIDs to generate at once. Each UUID will be printed on its own line and formatted as specified with the `--format` option.")
     var `repeat`: UInt = 1
     
+    @Option(help: "Causes the generated UUID to be the nil UUID")
+    var null = false
+    
+    
     mutating func run() throws {
         for _ in 1 ... max(1, self.repeat) {
-            print(format.apply(to: UUID()))
+            print(format.apply(to: null ? .null : UUID()))
         }
     }
 }

--- a/Sources/kyuuid/commands/kyuuid.swift
+++ b/Sources/kyuuid/commands/kyuuid.swift
@@ -25,7 +25,7 @@ struct kyuuid: ParsableCommand {
         """,
 
         // Commands can define a version for automatic '--version' support.
-        version: "0.2.2",
+        version: "0.3.0",
 
         // Pass an array to `subcommands` to set up a nested tree of subcommands.
         // With language support for type-level introspection, this could be

--- a/Tests/Test null UUID.swift
+++ b/Tests/Test null UUID.swift
@@ -16,12 +16,7 @@ struct Test_nullUuid {
     
     @Test("UUID.null should be the all‑zero value")
     func isAllZero() async throws {
-        let expected = UUID(uuid: uuid_t(
-            0,0,0,0,
-            0,0,
-            0,0,
-            0,0,
-            0,0,0,0,0,0))
+        let expected = UUID(uuid: uuid_t(0,0,0,0, 0,0, 0,0, 0,0, 0,0,0,0,0,0))
         #expect(UUID.null == expected)
     }
     

--- a/Tests/Test null UUID.swift
+++ b/Tests/Test null UUID.swift
@@ -1,0 +1,41 @@
+//
+//  Test null UUID.swift
+//  kyuuid
+//
+//  Created by Ky on 2026-01-30.
+//
+
+import Foundation
+import Testing
+
+import UuidTools
+
+
+
+struct Test_nullUuid {
+    
+    @Test("UUID.null should be the all‑zero value")
+    func isAllZero() async throws {
+        let expected = UUID(uuid: uuid_t(
+            0,0,0,0,
+            0,0,
+            0,0,
+            0,0,
+            0,0,0,0,0,0))
+        #expect(UUID.null == expected)
+    }
+    
+    
+    @Test("UUID.null canonical string representation")
+    func stringRepresentation_canonical() async throws {
+        #expect(UUID.null.uuidString == "00000000-0000-0000-0000-000000000000")
+        #expect(UUID.null.format(as: .standard) == "00000000-0000-0000-0000-000000000000")
+    }
+    
+    
+    @Test("UUID.null base-64 string representations")
+    func stringRepresentation() async throws {
+        #expect(UUID.null.format(as: .base64) == "AAAAAAAAAAAAAAAAAAAAAA==")
+        #expect(UUID.null.format(as: .truncatedBase64) == "AAAAAAAAAAAAAAAAAAAAAA")
+    }
+}


### PR DESCRIPTION
This introduces a new nil UUID constant `.null`, and lets the UUID generator create a “null” UUID via a command‑line flag.

The nil UUID is a useful placeholder for systems which don't accept no-value.


### SDK

The new `UUID.null` constant is introduced, which is always the value `00000000-0000-0000-0000-000000000000`. This should work as expected with all APIs which take a UUID.


### CLI
The new `--null` CLI option is introduced, which always outputs the nil UUID:
```
kyuuid --null
```
which will always output `00000000-0000-0000-0000-000000000000` (or the same UUID in the format specified by `--format`).

