### PR TITLE
Adding nil UUID docs, plus tiny changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,49 @@ If you just want to convert UUIDs from one UUID string format directly to anothe
 
 This package also ships as a binary executable to allow you to format, parse, and convert UUIDs from the command line.
 
+## Default operation
+
+Given no arguments, `kyuuid` just spits out a random UUID (version 4) in the canonical string representation.
+
+```plain
+% kyuuid
+49F26C1A-9122-4B01-AFB9-2C9B295BEA11
+```
+
+
+
+## Formatting
+
+`kyuuid` supports formatting UUIDs into the same string representations as `UuidTools`:
+
+```plain
+% kyuuid --format=standard
+AD13CA92-ACC7-42CD-A79F-6FDC38460661
+
+% kyuuid --format=base64  
+1oH/X3qVSbCMP7+gDqWjNQ==
+
+% kyuuid --format=truncatedBase64
+Any1DX0QRhW8iur4aQrupg
+```
+
+
+
 ## Converting
+
+Just as `kyuuid` supports outputting UUIDs in those formats, it also supports converting to and from them with the `convert` subcommand. You can select which format you're converting to with the `--to` flag, which accepts all formats that `kyuuid --format` accepts. If you omit the `--to` flag, the standard format is assumed.
+
+```plain
+% kyuuid convert Any1DX0QRhW8iur4aQrupg
+027CB50D-7D10-4615-BC8A-EAF8690AEEA6
+
+% kyuuid convert --to=base64 468FB857-3C7B-49E8-A642-344E8C5A525F
+Ro+4Vzx7SeimQjROjFpSXw==
+
+% kyuuid convert --to=truncatedBase64 468FB857-3C7B-49E8-A642-344E8C5A525F
+Ro+4Vzx7SeimQjROjFpSXw
+```
+
 
 
 ## Help output

--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ If you just want to convert UUIDs from one UUID string format directly to anothe
 
 
 
+## Predefined constants
+
+### The nil UUID
+
+[The nil UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier#Special_values) is `00000000-0000-0000-0000-000000000000`. This is useful for saying "no value" in a place which requires a value, like a database or as a dummy value in a preview/demo/PoC. `UuidTools` exposes this as the constant `UUID.null`:
+
+```swift
+#Preview {
+    UserProfileView(id: .null, name: "Rayne")
+}
+```
+
+
+
 
 
 # `kyuuid`
@@ -141,7 +155,7 @@ This utility offers 3 different formatting options:
 
 
 
-USAGE: kyuuid [--format <format>] [--repeat <repeat>] <subcommand>
+USAGE: kyuuid [--format <format>] [--repeat <repeat>] [--null] <subcommand>
 
 OPTIONS:
   --format <format>       The output format of the UUID(s) this generates. See
@@ -150,6 +164,7 @@ OPTIONS:
   --repeat <repeat>       The number of UUIDs to generate at once. Each UUID
                           will be printed on its own line and formatted as
                           specified with the `--format` option. (default: 1)
+  --null                  Causes the generated UUID to be the nil UUID
   --version               Show the version.
   -h, --help              Show help information.
 

--- a/Sources/kyuuid/commands/convert.swift
+++ b/Sources/kyuuid/commands/convert.swift
@@ -23,7 +23,7 @@ struct convert: ParsableCommand {
         """,
 
         // Commands can define a version for automatic '--version' support.
-        version: "0.1.1-lambda.4")
+        version: kyuuid.configuration.version)
     
     @Option
     var to: UuidFormat = .default

--- a/Sources/kyuuid/commands/kyuuid.swift
+++ b/Sources/kyuuid/commands/kyuuid.swift
@@ -40,6 +40,11 @@ struct kyuuid: ParsableCommand {
     
     
     mutating func run() throws {
+        guard 1 < self.repeat || isOutputToTerminal() else {
+            print(format.apply(to: null ? .null : UUID()), terminator: "")
+            return
+        }
+        
         for _ in 1 ... max(1, self.repeat) {
             print(format.apply(to: null ? .null : UUID()))
         }
@@ -62,4 +67,10 @@ private var formatsDiscussion: String {
     
     """}.joined())
     """
+}
+
+
+
+private func isOutputToTerminal() -> Bool {
+    return isatty(STDOUT_FILENO) != 0
 }

--- a/Sources/kyuuid/commands/kyuuid.swift
+++ b/Sources/kyuuid/commands/kyuuid.swift
@@ -24,7 +24,7 @@ struct kyuuid: ParsableCommand {
         \(formatsDiscussion)
         """,
         
-        version: "0.3.1",
+        version: "0.4.0",
         
         subcommands: [convert.self])
     

--- a/Sources/kyuuid/commands/kyuuid.swift
+++ b/Sources/kyuuid/commands/kyuuid.swift
@@ -23,13 +23,9 @@ struct kyuuid: ParsableCommand {
         
         \(formatsDiscussion)
         """,
-
-        // Commands can define a version for automatic '--version' support.
-        version: "0.3.0",
-
-        // Pass an array to `subcommands` to set up a nested tree of subcommands.
-        // With language support for type-level introspection, this could be
-        // provided by automatically finding nested `ParsableCommand` types.
+        
+        version: "0.3.1",
+        
         subcommands: [convert.self])
     
     
@@ -39,7 +35,7 @@ struct kyuuid: ParsableCommand {
     @Option(help: "The number of UUIDs to generate at once. Each UUID will be printed on its own line and formatted as specified with the `--format` option.")
     var `repeat`: UInt = 1
     
-    @Option(help: "Causes the generated UUID to be the nil UUID")
+    @Flag(help: "Causes the generated UUID to be the nil UUID")
     var null = false
     
     


### PR DESCRIPTION
## Documentation
This pull request documents the `--null` flag that lets the `kyuuid` CLI generate the nil UUID (all zeroes).

The documentation for `kyuuid` is also now more fleshed-out with sections for this new predefined constant, operation defaults, formatting, and conversion. The example help output is also updated to reflect the new flag.

## Bugfix
This PR fixes the bug where `kyuuid --null` would fail:
```plain
% kyuuid --null null 
Error: The value 'null' is invalid for '--null <null>'
Help:  --null <null>  Causes the generated UUID to be the nil UUID
Usage: kyuuid [--format <format>] [--repeat <repeat>] [--null <null>] <subcommand>
  See 'kyuuid --help' for more information.
```

That flag now works as intended:
```plain
% kyuuid --null     
00000000-0000-0000-0000-000000000000
```

## Tweak
This PR updates `kyuuid` so that when piping a single UUID to another command, no newline is sent:
```zsh
% kyuuid | wc -c
      36
```
The output byte count should match the character length of a single UUID string (36 for standard, 24 for base64, etc.) without an extra newline whenever piped out.

### Breaking Changes
Scripts & commands which relied on `kyuuid` piping with a trailing newline will no longer receive that, and must be updated to assume no trailing newline