### PR TITLE
feat: Rename --repeat option to --count

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,13 +197,13 @@ This utility offers 3 different formatting options:
 
 
 
-USAGE: kyuuid [--format <format>] [--repeat <repeat>] [--null] <subcommand>
+USAGE: kyuuid [--format <format>] [--count <count>] [--null] <subcommand>
 
 OPTIONS:
   --format <format>       The output format of the UUID(s) this generates. See
                           FORMATS for more info. (values: standard, base64,
                           truncatedBase64; default: standard)
-  --repeat <repeat>       The number of UUIDs to generate at once. Each UUID
+  --count <count>         The number of UUIDs to generate at once. Each UUID
                           will be printed on its own line and formatted as
                           specified with the `--format` option. (default: 1)
   --null                  Causes the generated UUID to be the nil UUID

--- a/Sources/kyuuid/commands/kyuuid.swift
+++ b/Sources/kyuuid/commands/kyuuid.swift
@@ -33,19 +33,19 @@ struct kyuuid: ParsableCommand {
     var format: UuidFormat = .default
     
     @Option(help: "The number of UUIDs to generate at once. Each UUID will be printed on its own line and formatted as specified with the `--format` option.")
-    var `repeat`: UInt = 1
+    var count: UInt = 1
     
     @Flag(help: "Causes the generated UUID to be the nil UUID")
     var null = false
     
     
     mutating func run() throws {
-        guard 1 < self.repeat || isOutputToTerminal() else {
+        guard 1 < self.count || isOutputToTerminal() else {
             print(format.apply(to: null ? .null : UUID()), terminator: "")
             return
         }
         
-        for _ in 1 ... max(1, self.repeat) {
+        for _ in 1 ... max(1, self.count) {
             print(format.apply(to: null ? .null : UUID()))
         }
     }


### PR DESCRIPTION
## Summary

Implements #4

As noted in the issue, `--repeat` implies that the same output is produced multiple times, which is misleading since each UUID generated is unique. This PR renames the flag to `--count` which better describes its purpose: specifying how many UUIDs to generate.

## Changes

- Renamed `repeat` property to `count` in `kyuuid.swift`
- Updated `run()` method to use the new property name
- Updated README.md to reflect the new flag name

## Breaking Change

⚠️ This is a breaking change for scripts or users relying on the `--repeat` flag. After this change, `--repeat` will no longer be recognized.

## Usage

**Before:**
```bash
kyuuid --repeat 5
```

**After:**
```bash
kyuuid --count 5
```